### PR TITLE
Fix/current shard

### DIFF
--- a/lib/octopus/result_patch.rb
+++ b/lib/octopus/result_patch.rb
@@ -1,19 +1,19 @@
-module Octopus::ResultPatch
-  attr_accessor :current_shard
-
-  private
-
-  def hash_rows
-    if current_shard.blank?
-      super
-    else
-      foo = super
-      foo.each { |f| f.merge!('current_shard' => current_shard) }
-      foo
-    end
-  end
-end
-
-class ActiveRecord::Result
-  prepend Octopus::ResultPatch
-end
+# module Octopus::ResultPatch
+#   attr_accessor :current_shard
+#
+#   private
+#
+#   def hash_rows
+#     if current_shard.blank?
+#       super
+#     else
+#       foo = super
+#       foo.each { |f| f.merge!('current_shard' => current_shard) }
+#       foo
+#     end
+#   end
+# end
+#
+# class ActiveRecord::Result
+#   prepend Octopus::ResultPatch
+# end

--- a/lib/octopus/result_patch.rb
+++ b/lib/octopus/result_patch.rb
@@ -1,19 +1,19 @@
-# module Octopus::ResultPatch
-#   attr_accessor :current_shard
-#
-#   private
-#
-#   def hash_rows
-#     if current_shard.blank?
-#       super
-#     else
-#       foo = super
-#       foo.each { |f| f.merge!('current_shard' => current_shard) }
-#       foo
-#     end
-#   end
-# end
-#
-# class ActiveRecord::Result
-#   prepend Octopus::ResultPatch
-# end
+module Octopus::ResultPatch
+  attr_accessor :current_shard
+
+  # private
+  #
+  # def hash_rows
+  #   if current_shard.blank?
+  #     super
+  #   else
+  #     foo = super
+  #     foo.each { |f| f.merge!('current_shard' => current_shard) }
+  #     foo
+  #   end
+  # end
+end
+
+class ActiveRecord::Result
+  prepend Octopus::ResultPatch
+end


### PR DESCRIPTION
Calling raw sql queries on the ActiveRecord connection with methods such as exec_query and select_all include the @current_shard value in the resulting AtiveRecord::Result object. If you call .to_hash, to_a or to_ary on the result, the current_shard property gets incorrectly merged into the results.

This issue stalled our deployment to production and to resolve it I had to comment out the following code in result_patch.rb

```ruby
module Octopus::ResultPatch
  attr_accessor :current_shard

  # private
  # 
  # def hash_rows
  #   if current_shard.blank?
  #     super
  #   else
  #     foo = super
  #     foo.each { |f| f.merge!('current_shard' => current_shard) }
  #     foo
  #   end
  # end
end

class ActiveRecord::Result
  prepend Octopus::ResultPatch
end
```

This code was introduced in #382c099